### PR TITLE
Fix string concat

### DIFF
--- a/snap/local/launcher
+++ b/snap/local/launcher
@@ -10,16 +10,16 @@ angle-compensate scan-mode udp-ip udp-port scan-frequency"
 for OPTION in ${OPTIONS}; do
   VALUE="$(snapctl get ${OPTION})"
   if [ -n "${VALUE}" ]; then
-    LAUNCH_OPTIONS+="${OPTION}:=${VALUE} "
+    LAUNCH_OPTIONS="${LAUNCH_OPTIONS} ${OPTION}:=${VALUE}"
   fi
 done
 
 VALUE="$(snapctl get serial-port)"
 if [ -n "${VALUE}" ]; then
-  LAUNCH_OPTIONS+="serial-port:=${VALUE} "
-elif [ -z "${RPLIDAR_AUTO_PATH}" ]; then
+  LAUNCH_OPTIONS="${LAUNCH_OPTIONS} serial-port:=${VALUE}"
+elif [ ! -z "${RPLIDAR_AUTO_PATH}" ]; then
   # Check if the path was set by the watcher script
-  LAUNCH_OPTIONS+="serial-port:=${RPLIDAR_AUTO_PATH} "
+  LAUNCH_OPTIONS="${LAUNCH_OPTIONS} serial-port:=${RPLIDAR_AUTO_PATH}"
 fi
 
 # Replace '-' with '_'

--- a/snap/local/watcher
+++ b/snap/local/watcher
@@ -21,9 +21,8 @@ udevadm monitor -k -s usb | while read START OP DEV REST; do
     # If not, look for it
     if [ -z "${RPLIDAR_AUTO_PATH}" ]; then
         if test "$START" = "KERNEL"; then
-            # First lines of "udevadm monitor" output,
+            # First lines of "udevadm monitor" output.
             # Check for already plugged devices.
-
             RPLIDAR_AUTO_PATH=`get_path`
 
         elif test "$OP" = "add"; then


### PR DESCRIPTION
For some reason Core doesn't like the `+=` operator for string concatenation in bash.

Edit: snaps daemon, when running on Core, doesn't like it. 